### PR TITLE
Fix ruby 2.4 incompatibilities.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,10 @@
 source "https://rubygems.org"
 
 gem "sinatra"
-gem "json"
+gem "json", "~> 2"
 gem "redis"
 gem "capistrano"
-gem "httparty"
+gem "httparty", "~> 0.15"
 gem "whenever"
 gem "aws-sdk", "~> 2"
 gem "dotenv"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,14 +27,13 @@ GEM
     dotenv (2.1.1)
     foreman (0.82.0)
       thor (~> 0.19.1)
-    httparty (0.13.7)
-      json (~> 1.8)
+    httparty (0.15.6)
       multi_xml (>= 0.5.2)
     i18n (0.7.0)
     jmespath (1.3.1)
-    json (1.8.3)
+    json (2.1.0)
     kgio (2.10.0)
-    multi_xml (0.5.5)
+    multi_xml (0.6.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (3.0.1)
@@ -43,8 +42,8 @@ GEM
       rack
     raindrops (0.15.0)
     rake (10.4.2)
-    redis (3.2.1)
-    sinatra (1.4.7)
+    redis (3.3.5)
+    sinatra (1.4.8)
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
@@ -73,8 +72,8 @@ DEPENDENCIES
   cityhash
   dotenv
   foreman
-  httparty
-  json
+  httparty (~> 0.15)
+  json (~> 2)
   redis
   sinatra
   unicorn


### PR DESCRIPTION
Upgrades a few gems for ruby 2.4 compatibility:

* json-1.8.3 fails to build under 2.4. Upgrade to 2.1.0.
* sinatra-1.4.7 and redis-3.2 produce warnings under 2.4.